### PR TITLE
Download Linux dependencies only.

### DIFF
--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -189,7 +189,7 @@ then
 	echo ""
 	pushd ./gitian-builder
 	mkdir -p inputs
-	make -C ../zcash/depends download SOURCES_PATH=`pwd`/cache/common
+	make -C ../zcash/depends download-linux SOURCES_PATH=`pwd`/cache/common
 
 	# Linux
 	if [[ $linux = true ]]


### PR DESCRIPTION
Previously, dependencies for all platforms were being downloaded.  This
causes issues because on Windows, the Rust dependency fails to download
as of Zcash v1.0.11-rc1, causing a checksum error.

This checksum error only manifested after a recent change to download a
different Rust package for each platform, (the Windows Rust package was
left unspecified whereas previously it downloaded the Linux package for
all platforms).