### PR TITLE
added fix for out of disk vagrant provision

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ gpg_key_id: ''
 ssh_key_name: ''
 ```
 
-Make sure VirtualBox, Vagrant and Ansible are installed, and then run:
+Make sure VirtualBox, Vagrant and Ansible are installed.
+
+Include this vagrant plugin to support resize of the start up disk:
+
+    vagrant plugin install vagrant-disksize
+
+Then run:
 
     vagrant up --provision zcash-build
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,10 @@
 Vagrant.configure(2) do |config|
 
   config.ssh.forward_agent = true
+  config.disksize.size = '16GB'
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo resize2fs /dev/sda1
+  SHELL
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/jessie64"
     gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true


### PR DESCRIPTION
Resolves #17 by including a plugin to resolve the disk size when provisioning the vm. Ups the default disk size from 9.6GB to 16GB. 
