### PR TITLE
Resize disk partition filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ gpg_key_id: ''
 ssh_key_name: ''
 ```
 
-Make sure VirtualBox, Vagrant and Ansible are installed, and then run:
+Make sure VirtualBox, Vagrant and Ansible are installed.
+
+Include this vagrant plugin to support resize of the start up disk:
+
+    vagrant plugin install vagrant-disksize
+
+Then run:
 
     vagrant up --provision zcash-build
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 Vagrant.configure(2) do |config|
 
   config.ssh.forward_agent = true
+  config.disksize.size = '16GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/jessie64"
     gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- include: repartition.yml
 - include: update_everything.yml
 - include: packages.yml
 - include: make_swap.yml

--- a/roles/common/tasks/repartition.yml
+++ b/roles/common/tasks/repartition.yml
@@ -1,0 +1,35 @@
+---
+- name: Make sure parted is installed
+  apt:
+    name: parted
+    state: present
+    update_cache: yes
+
+- name: Turn off all swap areas
+  command: swapoff -a
+  become: yes
+
+- name: Remove swap partition from /etc/fstab
+  mount:
+    path: none
+    fstype: swap
+    opts: sw
+    state: absent
+
+- name: Remove partition number 5
+  command: parted --script /dev/sda rm 5
+  become: yes
+
+- name: Remove partition number 2
+  command: parted --script /dev/sda rm 2
+  become: yes
+
+- name: Resize partition number 1 to fill the available space on the disk
+  command: parted ---pretend-input-tty /dev/sda unit % resizepart 1 yes 100
+  become: yes
+  register: parted_resize
+
+- name: Resize filesystem on /dev/sda1 to fill the available space on the partition
+  command: resize2fs /dev/sda1
+  become: yes
+  register: resize2fs


### PR DESCRIPTION
This PR is intended to resolve https://github.com/zcash/zcash-gitian/issues/17

It is similar to an earlier PR ( https://github.com/zcash/zcash-gitian/pull/20 ) but includes some updates:

- Ansible tasks instead of embedded script in Vagrantfile, matching the way most of the rest of the VM setup is done

- Removes swap partition from /etc/fstab in addition to removing it from partition table. This resolves an error that was preventing the swapfile from mounting. With the swapfile activated, the risk of running out of memory as discussed previously should be resolved. The swapfile size can be easily adjusted if necessary.