### PR TITLE
Remove instruction to install linux-headers-amd64 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ It relies upon [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://ww
 
 If you use Linux, we recommend obtaining VirtualBox through your package manager instead of the Oracle website.
 
-    sudo apt-get install linux-headers-amd64 virtualbox
-
-Linux kernel headers are required to setup the `/dev/vboxdrv` device and VirtualBox kernel module via `virtualbox-dkms`.
+    sudo apt-get install virtualbox
 
 #### Vagrant
 


### PR DESCRIPTION
Attempting to install `linux-headers-amd64` on an Ubuntu 16.0.4 VM failed with the following output
and after proceeding without it a build still succeeded.

```
parallels@parallels-vm:~$ sudo apt-get install linux-headers-amd64
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package linux-headers-amd64 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'linux-headers-amd64' has no installation candidate
parallels@parallels-vm:~$
```