### PR TITLE
Fixes on 'Check that the secret key exists' task

### DIFF
--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that the secret key exists.
-  local_action: "shell gpg2 --list-secret-keys | grep {{ gpg_key_id }}"
+  local_action: "shell gpg2 --list-secret-keys --with-colons | grep {{ gpg_key_id }}"
   register: gpg_list_keys_result
   environment:
     GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"

--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check that the secret key exists.
   local_action: "shell gpg2 --list-secret-keys --with-colons | grep {{ gpg_key_id }}"
+  ignore_errors: true
   register: gpg_list_keys_result
   environment:
     GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"

--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that the secret key exists.
-  local_action: "command gpg2 --list-secret-keys | grep {{ gpg_key_id }}"
+  local_action: "shell gpg2 --list-secret-keys | grep {{ gpg_key_id }}"
   register: gpg_list_keys_result
   environment:
     GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"


### PR DESCRIPTION
Fixing some issues with a task that checks for a gpg key matching a given id:

- A command using a pipe needs to be interpreted by a shell
- Use output format for parsing by scripts to reduces chance of false negatives
- Don't fail a build if it doesn't find they key, since it's marked optional
