### PR TITLE
VM provisioning fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ More independent Gitian builders are needed, which is why this guide exists.
 Requirements
 ------------
 
-4GB of RAM, at least two cores
+4GB of RAM, at least two cores. Four cores are recommended, as this has been seen to resolve a
+deadlock condition in the VM provisioning step.
 
 It relies upon [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/) plus [Ansible](https://www.ansible.com/).
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ gpg_key_id: ''
 ssh_key_name: ''
 ```
 
-Make sure VirtualBox, Vagrant and Ansible are installed.
-
 Include this vagrant plugin to support resize of the start up disk:
 
     vagrant plugin install vagrant-disksize

--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that the secret key exists.
-  local_action: "shell gpg2 --list-secret-keys | grep {{ gpg_key_id }}"
+  local_action: "shell gpg2 --list-secret-keys --with-colons | grep {{ gpg_key_id }}"
   register: gpg_list_keys_result
   environment:
     GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"

--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check that the secret key exists.
   local_action: "shell gpg2 --list-secret-keys --with-colons | grep {{ gpg_key_id }}"
+  become: no
   ignore_errors: true
   register: gpg_list_keys_result
   environment:
@@ -8,6 +9,7 @@
 
 - name: Export the GPG private key from the local keyring.
   local_action: "command gpg2 --armor --export-secret-key {{ gpg_key_id }}"
+  become: no
   register: gpg_private_key
   changed_when: false
   environment:

--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check that the secret key exists.
   local_action: "shell gpg2 --list-secret-keys --with-colons | grep {{ gpg_key_id }}"
+  ignore_errors: true
   register: gpg_list_keys_result
   environment:
     GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"

--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that the secret key exists.
-  local_action: "command gpg2 --list-secret-keys | grep {{ gpg_key_id }}"
+  local_action: "shell gpg2 --list-secret-keys | grep {{ gpg_key_id }}"
   register: gpg_list_keys_result
   environment:
     GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"

--- a/roles/gitian/tasks/ssh.yml
+++ b/roles/gitian/tasks/ssh.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check that the SSH key exists locally.
   local_action: "stat path={{ lookup('env', 'HOME') }}/.ssh/{{ ssh_key_name }}"
+  become: no
   register: ssh_key
 
 - name: Make SSH home directory.


### PR DESCRIPTION
Addresses a handful of issues I ran into when attempting to run the vagrant/ansible provisioning scripts:

- A command using a pipe operator needs to be run through a shell rather than executed directly.
- Use --with-colons (i.e. formatted for machines) operator to reduce variation in output from versions of gpg2.
- Add "become: no" property to ansible tasks using `local_action` to override the "become: yes" property they inherited, since sudo isn't needed on the host (ansible-running) node and this was causing password prompts to stop ansible's execution.
- Remove a redundant instruction in README.
- Suggest four cores instead of two. I ran into a deadlock using two and was able to get past it by switching to four.