### PR TITLE
Fix url intended to point to vagrant version 2.0.4

### DIFF
--- a/dependency_install_steps_by_platform/Debian_9.x.md
+++ b/dependency_install_steps_by_platform/Debian_9.x.md
@@ -76,7 +76,7 @@ As of this writing, the Vagrant version that Debian uses in its "stretch" releas
 suggest getting a package from Vagrant's web site:
 
 ```
-wget -c https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.4_x86_64.deb
+wget -c https://releases.hashicorp.com/vagrant/2.0.4/vagrant_2.0.4_x86_64.deb
 sudo dpkg -i vagrant_2.0.4_x86_64.deb
 ```
 


### PR DESCRIPTION
A url pointing to vagrant version 2.0.4 missed a directory named '2.0.3' in the path. Fixing that here.