### PR TITLE
Vagrant libvirt migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,14 +212,12 @@ or 16 characters. You should be able to use the truncated value.
 - `gpg_key_name`: the the part before the @ symbol of the associated email address. In our example
 this is `hpotter`.
 
-
-
 ## Provision a virtual machine
 
 From the project root directory, run:
 
 ```
-$ vagrant up --provision zcash-build
+$ sudo vagrant up --provider=kvm --provision zcash-build 
 ```
 
 This will provision a Gitian host virtual machine that uses a Linux container (LXC) guest to perform

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,20 +3,20 @@
 Vagrant.configure(2) do |config|
 
   config.ssh.forward_agent = true
-  config.disksize.size = '16GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/jessie64"
-    gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
+    gitian.vm.network :private_network, :ip => "10.0.2.15" 
     gitian.vm.provision "ansible" do |ansible|
       ansible.playbook = "gitian.yml"
       ansible.verbose = 'v'
       ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
     end
-    gitian.vm.provider "virtualbox" do |v|
-      v.name = "zcash-build"
-      v.memory = 4096
-      v.cpus = 2
+    gitian.vm.provider :libvirt do |domain|
+      domain.machine_virtual_size = 24
+      domain.memory = 15360 
+      domain.cpus = 4
     end
+    gitian.vm.hostname = "zcash-build"
 #    gitian.vm.synced_folder "~/.gnupg", "/home/vagrant/.gnupg", type: "sshfs"
 #    gitian.vm.synced_folder "./gitian.sigs", "/home/vagrant/gitian.sigs", create: true
 #    gitian.vm.synced_folder "./zcash-binaries", "/home/vagrant/zcash-binaries", create: true

--- a/gitian.yml
+++ b/gitian.yml
@@ -4,12 +4,12 @@
   hosts: localhost:zcash-build
   vars:
     zcash_git_repo_url: https://github.com/zcash/zcash
-    zcash_version: v1.0.8-1
-    gpg_key_name: ''
-    git_name: ''
-    git_email: ''
-    gpg_key_id: '' # optional
-    ssh_key_name: '' # optional
+    zcash_version: v2.0.3
+    gpg_key_name: 'naimed'
+    git_name: 'ianamunoz'
+    git_email: 'naimed@z.cash'
+    gpg_key_id: '73DE7067BA256794'
+    ssh_key_name: 'naimed' # optional
   roles:
     - role: common
       tags: common

--- a/roles/common/tasks/repartition.yml
+++ b/roles/common/tasks/repartition.yml
@@ -18,25 +18,25 @@
 
 - name: Remove partition number 5
   parted:
-    device: /dev/sda
+    device: /dev/vda
     number: 5
     state: absent
 
 - name: Remove partition number 2
   parted:
-    device: /dev/sda
+    device: /dev/vda
     number: 2
     state: absent
-  register: rm_part_2_sda_info
+  register: rm_part_2_vda_info
 
 - name: Resize partition 1 to reach end of disk if it does not already
-  command: parted ---pretend-input-tty /dev/sda unit % resizepart 1 yes 100
+  command: parted ---pretend-input-tty /dev/vda unit % resizepart 1 yes 100
   become: yes
-  when: rm_part_2_sda_info['disk']['size'] != rm_part_2_sda_info['partitions'][0]['end']
+  when: rm_part_2_vda_info['disk']['size'] != rm_part_2_vda_info['partitions'][0]['end']
   register: parted_resize
 
-- name: Resize filesystem on /dev/sda1 to fill the available space on the partition
+- name: Resize filesystem on /dev/vda1 to fill the available space on the partition
   filesystem:
-    dev: /dev/sda1
+    dev: /dev/vda1
     fstype: ext4
     resizefs: true

--- a/roles/gitian/defaults/main.yml
+++ b/roles/gitian/defaults/main.yml
@@ -20,3 +20,5 @@ zcash_developer_pubkeys:
     id: 0EC51FCDA94FB53E
   - name: simon
     id: C8F49C081F3AC6C4
+  - name: naimed
+    id: 73DE7067BA256794


### PR DESCRIPTION
This changes out the backend hypervisor from Oracle Virtualbox to KVM, if one wanted to use a different hypervisor.

Successfully produced matching signatures. There was an issue with the 'run-as' user for libvirt, which likes to be ran as root.

Not mergeable yet. Needs better documentation and either should be an option.

( I just have kvm running and didn't want to reload the kernel to swap the kernel modules for the vb ones... )