### PR TITLE
Fix version number typo

### DIFF
--- a/dependency_install_steps_by_platform/Debian_9.x.md
+++ b/dependency_install_steps_by_platform/Debian_9.x.md
@@ -138,7 +138,7 @@ ansible 2.5.1
 
 
 
-# Install GnuPG 2.x (2.11.18 or greater)
+# Install GnuPG 2.x (2.1.18 or greater)
 
 This is likely already installed and runnable via 'gpg'
 


### PR DESCRIPTION
This was meant to read "2.1.18".
GnuPG version 2.11.18 is not a thing (at least not so far)