### PR TITLE
Double-quote git name

### DIFF
--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -172,7 +172,7 @@
     seconds: 10
 
 - name: Set Git username.
-  command: "git config --global user.name '{{ git_name }}'"
+  command: "git config --global user.name \"{{ git_name }}\""
   become_user: "{{ gitian_user }}"
 
 - name: Set Git email address.


### PR DESCRIPTION
It failed on my name so this is intended to fix that.