### PR TITLE
Don't override GNUPGHOME

### DIFF
--- a/roles/gitian/tasks/gpg.yml
+++ b/roles/gitian/tasks/gpg.yml
@@ -4,16 +4,12 @@
   become: no
   ignore_errors: true
   register: gpg_list_keys_result
-  environment:
-    GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"
 
 - name: Export the GPG private key from the local keyring.
   local_action: "command gpg2 --armor --export-secret-key {{ gpg_key_id }}"
   become: no
   register: gpg_private_key
   changed_when: false
-  environment:
-    GNUPGHOME: "{{ lookup('env', 'HOME') }}/.gnupg"
   when: gpg_list_keys_result.stdout != ''
   no_log: True
 


### PR DESCRIPTION
A user may have set GNUPGHOME to a location other than $HOME/.gnupg and if they have, we should let gpg use that location.

gpg already defaults to $HOME/.gnupg if GNUPGHOME isn't set.