### PR TITLE
Update vagrant machine from jessie to stretch

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure(2) do |config|
   config.ssh.forward_agent = true
   config.disksize.size = '16GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
-    gitian.vm.box = "debian/jessie64"
+    gitian.vm.box = "debian/stretch64"
     gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
     gitian.vm.provision "ansible" do |ansible|
       ansible.playbook = "gitian.yml"

--- a/roles/common/files/50unattended-upgrades
+++ b/roles/common/files/50unattended-upgrades
@@ -1,6 +1,6 @@
 Unattended-Upgrade::Origins-Pattern {
-        "o=Debian,n=jessie-updates";
-        "o=Debian,n=jessie,l=Debian-Security";
+        "o=Debian,n=stretch-updates";
+        "o=Debian,n=stretch,l=Debian-Security";
 };
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
 Unattended-Upgrade::Automatic-Reboot "false";

--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -24,6 +24,7 @@
     - gnupg2
     - kpartx
     - lintian
+    - lxc
     - make
     - python-cheetah
     - qemu-utils
@@ -106,19 +107,6 @@
     owner: root
     group: root
     mode: "0644"
-
-- name: Set up jessie-backports.
-  apt_repository:
-    repo: 'deb http://httpredir.debian.org/debian/ jessie-backports main'
-    state: present
-
-- name: Install updated version of LXC.
-  apt:
-    name: lxc
-    state: latest
-    default_release: jessie-backports
-    update_cache: yes
-    cache_valid_time: 3600
 
 - name: Clone git repository for Gitian builder.
   git:


### PR DESCRIPTION
We ran into an error ( https://github.com/zcash/zcash-gitian/issues/56 ) when attempting to launch commands in an LXC container within a Debian 8 (Jessie) machine started by Vagrant.

I was able to reproduce the error. Then, after this change which updates the machine provisioned by Vagrant to Debian 9 (Stretch), and modifies the LXC package to install from the standard stretch repository rather than from the 'backports' repository it has been using, I was able to run the gitian build to completion.

This change should not have any effect on the content and hashes produced by the build being signed, and by extension on the signatures produced. The machine being updated here is the one outside, not inside, the LXC container.