### PR TITLE
Add a stretch container to the build VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   }
 
   config.ssh.forward_agent = true
-  config.disksize.size = '16GB'
+  config.disksize.size = '20GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/stretch64"
     gitian.vm.box_version = "9.9.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
     gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
     gitian.vm.provision "ansible" do |ansible|
       ansible.playbook = "gitian.yml"
-      ansible.verbose = 'v'
+      ansible.verbose = 'vvv'
       ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
     end
     gitian.vm.provider "virtualbox" do |v|

--- a/roles/gitian/defaults/main.yml
+++ b/roles/gitian/defaults/main.yml
@@ -3,8 +3,8 @@ gitian_user: vagrant
 download_directory: /tmp/gitian
 vm_builder_name: 'vm-builder-0.12.4+bzr494'
 vm_builder_url: 'http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr494.orig.tar.gz'
-gitian_builder_url: https://github.com/devrandom/gitian-builder
-gitian_builder_version: master
+gitian_builder_url: https://github.com/charlieok/gitian-builder
+gitian_builder_version: separate_dirs_for_separate_builds
 zcash_git_repo_url: https://github.com/zcash/zcash
 zcash_gitian_sigs_repo: https://github.com/zcash/gitian.sigs
 zcash_version: master

--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -175,14 +175,28 @@
     mode: "0755"
   tags: script
 
-- name: Check for presence of Gitian LXC image.
+- name: Check for presence of Gitian LXC jessie image.
   stat:
     path: "/home/{{ gitian_user }}/gitian-builder/base-jessie-amd64"
-  register: gitian_lxc_image
+  register: gitian_lxc_jessie_image
 
-- name: Set up the Gitian LXC image.
+- name: Set up the Gitian LXC jessie image.
   shell: "source ~/.profile && /home/{{ gitian_user }}/gitian-builder/bin/make-base-vm --lxc --arch amd64 --distro debian --suite jessie"
-  when: gitian_lxc_image.stat.exists == false
+  when: gitian_lxc_jessie_image.stat.exists == false
+  become: yes
+  become_user: "{{ gitian_user }}"
+  args:
+    chdir: "/home/{{ gitian_user }}/gitian-builder"
+    executable: /bin/bash
+
+- name: Check for presence of Gitian LXC stretch image.
+  stat:
+    path: "/home/{{ gitian_user }}/gitian-builder/base-stretch-amd64"
+  register: gitian_lxc_stretch_image
+
+- name: Set up the Gitian LXC stretch image.
+  shell: "source ~/.profile && /home/{{ gitian_user }}/gitian-builder/bin/make-base-vm --lxc --arch amd64 --distro debian --suite stretch"
+  when: gitian_lxc_stretch_image.stat.exists == false
   become: yes
   become_user: "{{ gitian_user }}"
   args:


### PR DESCRIPTION
We want to add builds for stretch. Adding setup steps to create a container running the Debian 9 stretch release. Also increasing the VM size to allow extra room for the added container.