### PR TITLE
Add configuration parameter for gitian_builder_version

### DIFF
--- a/roles/gitian/defaults/main.yml
+++ b/roles/gitian/defaults/main.yml
@@ -4,6 +4,7 @@ download_directory: /tmp/gitian
 vm_builder_name: 'vm-builder-0.12.4+bzr494'
 vm_builder_url: 'http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr494.orig.tar.gz'
 gitian_builder_url: https://github.com/devrandom/gitian-builder
+gitian_builder_version: master
 zcash_git_repo_url: https://github.com/zcash/zcash
 zcash_gitian_sigs_repo: https://github.com/zcash/gitian.sigs
 zcash_version: master

--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -111,7 +111,7 @@
   git:
     repo: "{{ gitian_builder_url }}"
     dest: "/home/{{ gitian_user }}/gitian-builder"
-    version: "master"
+    version: "gitian_builder_version"
     force: yes
   become_user: "{{ gitian_user }}"
 


### PR DESCRIPTION
I want the flexibility to more easily point to other gitian-builder branches