### PR TITLE
Build for more than one Debian release 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   }
 
   config.ssh.forward_agent = true
-  config.disksize.size = '20GB'
+  config.disksize.size = '24GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/stretch64"
     gitian.vm.box_version = "9.9.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   }
 
   config.ssh.forward_agent = true
-  config.disksize.size = '16GB'
+  config.disksize.size = '20GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/stretch64"
     gitian.vm.box_version = "9.9.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
     gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
     gitian.vm.provision "ansible" do |ansible|
       ansible.playbook = "gitian.yml"
-      ansible.verbose = 'v'
+      ansible.verbose = 'vvv'
       ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
     end
     gitian.vm.provider "virtualbox" do |v|

--- a/roles/gitian/files/explode_yaml_file.py
+++ b/roles/gitian/files/explode_yaml_file.py
@@ -80,6 +80,7 @@ with open(input_file_path) as fp:
 sequence = data[args.key_to_explode]
 
 for item in sequence:
+    print item
     item_dir_path = os.path.join(output_dir_path, item)
 
     if not os.path.exists(item_dir_path):

--- a/roles/gitian/files/explode_yaml_file.py
+++ b/roles/gitian/files/explode_yaml_file.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import os
+import ruamel.yaml
+
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+# For a command like this...
+#
+# explode_yaml_file.py zcash/contrib/gitian-descriptors/gitian-linux.yml suites output_dir
+#
+# ...with a gitian-linux.yml file like this...
+#
+# ---
+# distro: "debian"
+# suites:
+# - "jessie"
+# - "stretch"
+# architectures:
+# - "amd64"
+#
+# ...will write out a structure like this:
+#
+# output_dir/
+# ├─ jessie/
+# │  └─ gitian-linux.yml  content:
+# │                       ---
+# │                       distro: "debian"
+# │                       suites:
+# │                       - "jessie"
+# │                       architectures:
+# │                       - "amd64"
+# │
+# └─ stretch
+#    └─ gitian-linux.yml  content:
+#                         ---
+#                         distro: "debian"
+#                         suites:
+#                         - "stretch"
+#                         architectures:
+#                         - "amd64"
+#
+# This approach is working around a limitation of gitian-builder: when
+# passed a descriptor file with more than one entry in 'suites', it
+# overwrites products of earlier builds with products of later builds.
+# We 'explode' our descriptor file into potentially many single-suite
+# descriptor files which we then pass to gitian-builder one at a time.
+
+
+parser = argparse.ArgumentParser(description='YAML file exploder')
+
+parser.add_argument('input_file_path',
+                    type=str,
+                    help='Path to the input file')
+
+parser.add_argument('key_to_explode',
+                    type=str,
+                    help='The key in the input file to explode (should be a sequence)')
+
+parser.add_argument('output_dir_path',
+                    type=str,
+                    help='Path to the output directory')
+
+args = parser.parse_args()
+
+yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
+
+input_file_path = args.input_file_path
+output_dir_path = args.output_dir_path
+
+file_name = os.path.basename(input_file_path)
+
+
+with open(input_file_path) as fp:
+    data = yaml.load(fp)
+
+sequence = data[args.key_to_explode]
+
+for item in sequence:
+    item_dir_path = os.path.join(output_dir_path, item)
+
+    if not os.path.exists(item_dir_path):
+        os.makedirs(item_dir_path)
+
+    data[args.key_to_explode] = [DoubleQuotedScalarString(item)]
+
+    output_file_path = os.path.join(item_dir_path, file_name)
+    with open(output_file_path, 'w') as fp:
+        yaml.dump(data, fp)

--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -170,6 +170,20 @@
   command: "git config --global user.email '{{ git_email }}'"
   become_user: "{{ gitian_user }}"
 
+- name: Create bin directory under gitian_user home directory
+  file:
+    state: directory
+    dest: "/home/{{ gitian_user }}/bin"
+    mode: "0755"
+
+- name: Copy explode_yaml_file.py
+  copy:
+    src: explode_yaml_file.py
+    dest: "/home/{{ gitian_user }}/bin/explode_yaml_file.py"
+    owner: "{{ gitian_user }}"
+    group: "{{ gitian_user }}"
+    mode: "0755"
+
 - name: Copy Gitian build script.
   template:
     src: gitian-build.sh

--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -30,6 +30,10 @@
     state: present
     update_cache: yes
 
+- name: Install ruamel.yaml
+  pip:
+    name: "ruamel.yaml"
+
 - name: Set up the Gitian build user with sudo.
   user:
     name: "{{ gitian_user }}"

--- a/roles/gitian/tasks/main.yml
+++ b/roles/gitian/tasks/main.yml
@@ -175,20 +175,6 @@
     mode: "0755"
   tags: script
 
-- name: Check for presence of Gitian LXC image.
-  stat:
-    path: "/home/{{ gitian_user }}/gitian-builder/base-jessie-amd64"
-  register: gitian_lxc_image
-
-- name: Set up the Gitian LXC image.
-  shell: "source ~/.profile && /home/{{ gitian_user }}/gitian-builder/bin/make-base-vm --lxc --arch amd64 --distro debian --suite jessie"
-  when: gitian_lxc_image.stat.exists == false
-  become: yes
-  become_user: "{{ gitian_user }}"
-  args:
-    chdir: "/home/{{ gitian_user }}/gitian-builder"
-    executable: /bin/bash
-
 - name: Clean the apt cache to free up space.
   apt:
     autoclean: yes

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -212,6 +212,8 @@ then
             echo ""
             pushd ${gitian_builder_repo_path}
             mkdir -p inputs
+            rm -rf ${gitian_builder_repo_path}/cache/* # Clear cache directory before each build
+
             make -C ${zcash_repo_dir_path}/depends download SOURCES_PATH=${gitian_builder_repo_path}/cache/common
 
             suite_image_path=${gitian_builder_repo_path}/base-${suite}-amd64

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -237,21 +237,21 @@ then
             mv ${build_dir_path}/out/zcash-*.tar.gz ${build_dir_path}/out/src/zcash-*.tar.gz ${suite_binaries_dir_path}
 
             popd  # pushd ${gitian_builder_repo_path}
+
+
+            if [[ $commitFiles = true ]]
+            then
+	            # Commit to gitian.sigs repo
+                echo ""
+                echo "Committing ${VERSION} Signatures"
+                echo ""
+                pushd ${gitian_sigs_repo_path}
+                git add ${VERSION}_${suite}/${SIGNER}
+                git commit -a -m "Add ${VERSION}_${suite} signatures for ${SIGNER}"
+                popd
+            fi
         done
-
 	fi
-
-        if [[ $commitFiles = true ]]
-        then
-	    # Commit to gitian.sigs repo
-            echo ""
-            echo "Committing ${VERSION} Signatures"
-            echo ""
-            pushd ${gitian_sigs_repo_path}
-            git add ${VERSION}_${suite}/${SIGNER}
-            git commit -a -m "Add ${VERSION}_${suite} signatures for ${SIGNER}"
-            popd
-        fi
 fi
 
 # Verify the build

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -23,6 +23,7 @@ signProg="gpg --detach-sign"
 commitFiles=true
 
 zcash_repo_dir_path=${HOME}/zcash
+zcash_binaries_dir_path=${HOME}/zcash-binaries
 
 # Help Message
 read -d '' usage <<- EOF
@@ -183,7 +184,7 @@ popd
 if [[ $build = true ]]
 then
 	# Make output folder
-	mkdir -p ./zcash-binaries/${VERSION}
+	mkdir -p ${zcash_binaries_dir_path}/${VERSION}
 
 	# Build Dependencies
 	echo ""
@@ -201,7 +202,7 @@ then
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
 	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ../gitian.sigs/ ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
-	    mv build/out/zcash-*.tar.gz build/out/src/zcash-*.tar.gz ../zcash-binaries/${VERSION}
+	    mv build/out/zcash-*.tar.gz build/out/src/zcash-*.tar.gz ${zcash_binaries_dir_path}/${VERSION}
 	fi
 	popd
 

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -194,7 +194,7 @@ then
 	# Linux
 	if [[ $linux = true ]]
 	then
-            echo ""
+        echo ""
 	    echo "Compiling ${VERSION} Linux"
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ../zcash/contrib/gitian-descriptors/gitian-linux.yml

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -243,7 +243,7 @@ then
             then
 	            # Commit to gitian.sigs repo
                 echo ""
-                echo "Committing ${VERSION} Signatures"
+                echo "Committing ${VERSION}_${suite} Signatures"
                 echo ""
                 pushd ${gitian_sigs_repo_path}
                 git add ${VERSION}_${suite}/${SIGNER}

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -22,6 +22,8 @@ scriptName=$(basename -- "$0")
 signProg="gpg --detach-sign"
 commitFiles=true
 
+zcash_repo_dir_path=${HOME}/zcash
+
 # Help Message
 read -d '' usage <<- EOF
 Usage: $scriptName [-c|u|v|b|s|B|o|h|j|m|] signer version
@@ -172,7 +174,7 @@ fi
 echo ${COMMIT}
 
 # Set up build
-pushd ./zcash
+pushd ${zcash_repo_dir_path}
 git fetch
 git checkout ${COMMIT}
 popd
@@ -189,7 +191,7 @@ then
 	echo ""
 	pushd ./gitian-builder
 	mkdir -p inputs
-	make -C ../zcash/depends download SOURCES_PATH=`pwd`/cache/common
+	make -C ${zcash_repo_dir_path}/depends download SOURCES_PATH=`pwd`/cache/common
 
 	# Linux
 	if [[ $linux = true ]]
@@ -197,8 +199,8 @@ then
         echo ""
 	    echo "Compiling ${VERSION} Linux"
 	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ../zcash/contrib/gitian-descriptors/gitian-linux.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ../gitian.sigs/ ../zcash/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ../gitian.sigs/ ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
 	    mv build/out/zcash-*.tar.gz build/out/src/zcash-*.tar.gz ../zcash-binaries/${VERSION}
 	fi
 	popd
@@ -224,7 +226,7 @@ then
 	echo ""
 	echo "Verifying ${VERSION} Linux"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION} ../zcash/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
 	popd
 fi
 

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -225,8 +225,8 @@ then
             fi
 
             echo ""
-	        echo "Compiling ${VERSION} Linux"
-	        echo ""
+            echo "Compiling variant: ${VERSION}_${suite}"
+            echo ""
 
             ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ${suite_dir_path}/gitian-linux.yml
             ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}_${suite} --destination ${gitian_sigs_repo_path}/ ${suite_dir_path}/gitian-linux.yml

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -197,14 +197,6 @@ then
 	# Make output folder
 	mkdir -p ${zcash_binaries_dir_path}/${VERSION}
 
-	# Build Dependencies
-	echo ""
-	echo "Building Dependencies"
-	echo ""
-	pushd ${gitian_builder_repo_path}
-	mkdir -p inputs
-	make -C ${zcash_repo_dir_path}/depends download SOURCES_PATH=${gitian_builder_repo_path}/cache/common
-
 	# Linux
 	if [[ $linux = true ]]
 	then
@@ -213,6 +205,14 @@ then
 
             suite_dir_path=${suite_descriptors_dir_path}/${suite}
             echo "suite_dir_path: ${suite_dir_path}"
+
+            # Build Dependencies
+            echo ""
+            echo "Building Dependencies"
+            echo ""
+            pushd ${gitian_builder_repo_path}
+            mkdir -p inputs
+            make -C ${zcash_repo_dir_path}/depends download SOURCES_PATH=${gitian_builder_repo_path}/cache/common
 
             suite_image_path=${gitian_builder_repo_path}/base-${suite}-amd64
             echo "suite_image_path: ${suite_image_path}"
@@ -233,10 +233,11 @@ then
             mkdir ${suite_binaries_dir_path}
 
             mv ${build_dir_path}/out/zcash-*.tar.gz ${build_dir_path}/out/src/zcash-*.tar.gz ${suite_binaries_dir_path}
+
+            popd  # pushd ${gitian_builder_repo_path}
         done
 
 	fi
-	popd
 
         if [[ $commitFiles = true ]]
         then

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -224,7 +224,7 @@ then
 	        echo ""
 
             ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ${suite_dir_path}/gitian-linux.yml
-            ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ${gitian_sigs_repo_path}/ ${suite_dir_path}/gitian-linux.yml
+            ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}_${suite} --destination ${gitian_sigs_repo_path}/ ${suite_dir_path}/gitian-linux.yml
 
             suite_binaries_dir_path=${zcash_binaries_dir_path}/${VERSION}/${suite}
             mkdir ${suite_binaries_dir_path}
@@ -251,30 +251,40 @@ fi
 # Verify the build
 if [[ $verify = true ]]
 then
-	# Linux
-	pushd ${gitian_builder_repo_path}
-	echo ""
-	echo "Verifying ${VERSION} Linux"
-	echo ""
-	./bin/gverify -v -d ${gitian_sigs_repo_path}/ -r ${VERSION} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
-	popd
+    # Linux
+    pushd ${gitian_builder_repo_path}
+
+    for suite in ${suites} ; do
+        echo "processing suite ${suite}"
+
+        suite_dir_path=${suite_descriptors_dir_path}/${suite}
+        echo "suite_dir_path: ${suite_dir_path}"
+
+        echo ""
+        echo "Verifying ${VERSION}_${suite} Linux"
+        echo ""
+
+        ./bin/gverify -v -d ${gitian_sigs_repo_path}/ -r ${VERSION}_${suite} ${suite_dir_path}/gitian-linux.yml
+    done
+
+    popd
 fi
 
 # Sign binaries
 if [[ $sign = true ]]
 then
 
-        pushd ${gitian_builder_repo_path}
+    pushd ${gitian_builder_repo_path}
 	popd
 
-        if [[ $commitFiles = true ]]
-        then
-            # Commit Sigs
-            pushd ${gitian_sigs_repo_path}
-            echo ""
-            echo "Committing ${VERSION} Signed Binary Signatures"
-            echo ""
-            git commit -a -m "Add ${VERSION} signed binary signatures for ${SIGNER}"
-            popd
-        fi
+    if [[ $commitFiles = true ]]
+    then
+        # Commit Sigs
+        pushd ${gitian_sigs_repo_path}
+        echo ""
+        echo "Committing ${VERSION} Signed Binary Signatures"
+        echo ""
+        git commit -a -m "Add ${VERSION} signed binary signatures for ${SIGNER}"
+        popd
+    fi
 fi

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -27,6 +27,8 @@ gitian_sigs_repo_path=${HOME}/gitian.sigs
 zcash_repo_dir_path=${HOME}/zcash
 zcash_binaries_dir_path=${HOME}/zcash-binaries
 
+build_dir_path=${gitian_builder_repo_path}/build
+
 # Help Message
 read -d '' usage <<- EOF
 Usage: $scriptName [-c|u|v|b|s|B|o|h|j|m|] signer version
@@ -204,7 +206,7 @@ then
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
 	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ${gitian_sigs_repo_path}/ ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
-	    mv build/out/zcash-*.tar.gz build/out/src/zcash-*.tar.gz ${zcash_binaries_dir_path}/${VERSION}
+	    mv ${build_dir_path}/out/zcash-*.tar.gz ${build_dir_path}/out/src/zcash-*.tar.gz ${zcash_binaries_dir_path}/${VERSION}
 	fi
 	popd
 

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -24,7 +24,10 @@ commitFiles=true
 
 gitian_builder_repo_path=${HOME}/gitian-builder
 gitian_sigs_repo_path=${HOME}/gitian.sigs
+
 zcash_repo_dir_path=${HOME}/zcash
+gitian_descriptor_path=${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
+
 zcash_binaries_dir_path=${HOME}/zcash-binaries
 
 build_dir_path=${gitian_builder_repo_path}/build
@@ -185,7 +188,8 @@ git fetch
 git checkout ${COMMIT}
 popd
 
-explode_yaml_file.py ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml suites ${suite_descriptors_dir_path}
+
+explode_yaml_file.py ${gitian_descriptor_path} suites ${suite_descriptors_dir_path}
 suites=$(ls ${suite_descriptors_dir_path})
 
 # Build

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -189,8 +189,7 @@ git checkout ${COMMIT}
 popd
 
 
-explode_yaml_file.py ${gitian_descriptor_path} suites ${suite_descriptors_dir_path}
-suites=$(ls ${suite_descriptors_dir_path})
+suites=$(explode_yaml_file.py ${gitian_descriptor_path} suites ${suite_descriptors_dir_path})
 
 # Build
 if [[ $build = true ]]

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -248,8 +248,8 @@ then
             echo "Committing ${VERSION} Signatures"
             echo ""
             pushd ${gitian_sigs_repo_path}
-            git add ${VERSION}/${SIGNER}
-            git commit -a -m "Add ${VERSION} signatures for ${SIGNER}"
+            git add ${VERSION}_${suite}/${SIGNER}
+            git commit -a -m "Add ${VERSION}_${suite} signatures for ${SIGNER}"
             popd
         fi
 fi

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -23,6 +23,7 @@ signProg="gpg --detach-sign"
 commitFiles=true
 
 gitian_builder_repo_path=${HOME}/gitian-builder
+gitian_sigs_repo_path=${HOME}/gitian.sigs
 zcash_repo_dir_path=${HOME}/zcash
 zcash_binaries_dir_path=${HOME}/zcash-binaries
 
@@ -202,7 +203,7 @@ then
 	    echo "Compiling ${VERSION} Linux"
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit zcash=${COMMIT} --url zcash=${url} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ../gitian.sigs/ ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION} --destination ${gitian_sigs_repo_path}/ ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
 	    mv build/out/zcash-*.tar.gz build/out/src/zcash-*.tar.gz ${zcash_binaries_dir_path}/${VERSION}
 	fi
 	popd
@@ -213,7 +214,7 @@ then
             echo ""
             echo "Committing ${VERSION} Signatures"
             echo ""
-            pushd gitian.sigs
+            pushd ${gitian_sigs_repo_path}
             git add ${VERSION}/${SIGNER}
             git commit -a -m "Add ${VERSION} signatures for ${SIGNER}"
             popd
@@ -228,7 +229,7 @@ then
 	echo ""
 	echo "Verifying ${VERSION} Linux"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gverify -v -d ${gitian_sigs_repo_path}/ -r ${VERSION} ${zcash_repo_dir_path}/contrib/gitian-descriptors/gitian-linux.yml
 	popd
 fi
 
@@ -242,7 +243,7 @@ then
         if [[ $commitFiles = true ]]
         then
             # Commit Sigs
-            pushd gitian.sigs
+            pushd ${gitian_sigs_repo_path}
             echo ""
             echo "Committing ${VERSION} Signed Binary Signatures"
             echo ""

--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -22,6 +22,7 @@ scriptName=$(basename -- "$0")
 signProg="gpg --detach-sign"
 commitFiles=true
 
+gitian_builder_repo_path=${HOME}/gitian-builder
 zcash_repo_dir_path=${HOME}/zcash
 zcash_binaries_dir_path=${HOME}/zcash-binaries
 
@@ -190,9 +191,9 @@ then
 	echo ""
 	echo "Building Dependencies"
 	echo ""
-	pushd ./gitian-builder
+	pushd ${gitian_builder_repo_path}
 	mkdir -p inputs
-	make -C ${zcash_repo_dir_path}/depends download SOURCES_PATH=`pwd`/cache/common
+	make -C ${zcash_repo_dir_path}/depends download SOURCES_PATH=${gitian_builder_repo_path}/cache/common
 
 	# Linux
 	if [[ $linux = true ]]
@@ -223,7 +224,7 @@ fi
 if [[ $verify = true ]]
 then
 	# Linux
-	pushd ./gitian-builder
+	pushd ${gitian_builder_repo_path}
 	echo ""
 	echo "Verifying ${VERSION} Linux"
 	echo ""
@@ -235,7 +236,7 @@ fi
 if [[ $sign = true ]]
 then
 
-        pushd ./gitian-builder
+        pushd ${gitian_builder_repo_path}
 	popd
 
         if [[ $commitFiles = true ]]

--- a/roles/gitian/templates/profile
+++ b/roles/gitian/templates/profile
@@ -22,7 +22,6 @@ if [ -d "$HOME/bin" ] ; then
 fi
 
 export DISTRO=debian
-export SUITE=jessie
 export ARCH=amd64
 export USE_LXC=1
 export LXC_BRIDGE=lxcbr0


### PR DESCRIPTION
This project seems to have been written to build for one-debian-release-at-a-time. This PR aims to change that.

- Moved debian image creation from ansible VM-setup tasks to build script -- we use the descriptor file from the zcash project to determine which release(s) we are building for.

- Added a script to "explode" a gitian descriptor file into multiple descriptor files, each containing one 'suite' entry from the original. (Passing the file unmodified to gitian-builder causes it to copy later build products over earlier ones). Added the ruamel.yaml python package to help with this, since it seems good at making local modifications to yaml files while passing the rest through untouched.

- Increased the VM disk size from 16GB to 24 GB to make room for a build that creates images and containers for debian jessie + debian stretch.

- Save build output binaries in separate directories for each suite, since the executables can have identical names.

- Add the 'suite' value (in our case the debian release name) to the 'release' name used to generate and verify gitian build signatures.

- Build suites in the order they are listed in the input gitian descriptor.