### PR TITLE
Copy .deb package from gitian output directory in addition to .tar files

### DIFF
--- a/roles/gitian/templates/gitian-build.sh
+++ b/roles/gitian/templates/gitian-build.sh
@@ -223,6 +223,7 @@ then
             mkdir ${suite_binaries_dir_path}
 
             mv ${build_dir_path}/out/zcash-*.tar.gz ${build_dir_path}/out/src/zcash-*.tar.gz ${suite_binaries_dir_path}
+            mv ${build_dir_path}/out/zcash-*.deb ${suite_binaries_dir_path}
 
             popd  # pushd ${gitian_builder_repo_path}
 


### PR DESCRIPTION
This update is a companion to this PR in the zcash project:

Create deb package in gitian build
https://github.com/zcash/zcash/pull/4071

That PR updates the gitian build script in the zcash repository to output a `.deb` package file. This PR updates the `gitian-build.sh` script in this project to retrieve that file outside the container where the build is run, and place it alongside the other build output files where the user can find it.