### PR TITLE
update debian/stretch64 vagrant box from 9.9.0 to 9.12.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(2) do |config|
   config.disksize.size = '24GB'
   config.vm.define 'zcash-build', autostart: false do |gitian|
     gitian.vm.box = "debian/stretch64"
-    gitian.vm.box_version = "9.9.0"
+    gitian.vm.box_version = "9.12.0"
     gitian.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
     gitian.vm.provision "ansible" do |ansible|
       ansible.playbook = "gitian.yml"


### PR DESCRIPTION
This is a spot I wasn't thinking of regularly when updating but when troubleshooting today realized was out-of-date. Updated to current which didn't seem to break anything.