### PR TITLE
disable rsync

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,11 @@ Vagrant.configure(2) do |config|
       v.memory = 4096
       v.cpus = 2
     end
+
+    # Added to disable synced folders
+    # https://www.vagrantup.com/docs/synced-folders/basic_usage#disabling
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+
 #    gitian.vm.synced_folder "~/.gnupg", "/home/vagrant/.gnupg", type: "sshfs"
 #    gitian.vm.synced_folder "./gitian.sigs", "/home/vagrant/gitian.sigs", create: true
 #    gitian.vm.synced_folder "./zcash-binaries", "/home/vagrant/zcash-binaries", create: true


### PR DESCRIPTION
vagrant provisioning got stuck when attempting to install rsync, and then later got stuck again when attempting to run rsync. This isn't needed in our current setup, and disabling it got me past that hurdle and allowed the VM to finish provisioning.