### PR TITLE
Bump vagrant-scp to 0.5.9

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure(2) do |config|
 
   config.vagrant.plugins = {
     "vagrant-disksize" => {"version" => "0.1.3"},
-    "vagrant-scp" => {"version" => "0.5.7"}
+    "vagrant-scp" => {"version" => "0.5.9"}
   }
 
   config.ssh.forward_agent = true


### PR DESCRIPTION
This update to vagrant-scp resolves a version conflict that was keeping us on vagrant 2.2.16 for a while.

https://github.com/hashicorp/vagrant/issues/12504